### PR TITLE
Fix image export in CramerGAN/MMDGAN

### DIFF
--- a/CramerGAN/gan/utils/misc.py
+++ b/CramerGAN/gan/utils/misc.py
@@ -12,6 +12,8 @@ from time import gmtime, strftime
 import tensorflow as tf
 from six.moves import xrange
 
+from PIL import Image
+
 pp = pprint.PrettyPrinter()
 
 def inverse_transform(images):
@@ -19,8 +21,10 @@ def inverse_transform(images):
 
 
 def save_images(images, size, image_path):
-    merged = merge(inverse_transform(images), size)
-    return scipy.misc.imsave(image_path, merged)
+    merged = merge(images, size)
+    merged *= 255. # scale back to [0, 255]
+    merged = np.clip(merged, 0., 255.).astype(np.uint8)
+    return Image.fromarray(merged).save(image_path)
 
 
 def merge(images, size):

--- a/MMDGAN/gan/utils/misc.py
+++ b/MMDGAN/gan/utils/misc.py
@@ -12,6 +12,8 @@ from time import gmtime, strftime
 import tensorflow as tf
 from six.moves import xrange
 
+from PIL import Image
+
 pp = pprint.PrettyPrinter()
 
 def inverse_transform(images):
@@ -19,8 +21,10 @@ def inverse_transform(images):
 
 
 def save_images(images, size, image_path):
-    merged = merge(inverse_transform(images), size)
-    return scipy.misc.imsave(image_path, merged)
+    merged = merge(images, size)
+    merged *= 255. # scale back to [0, 255]
+    merged = np.clip(merged, 0., 255.).astype(np.uint8)
+    return Image.fromarray(merged).save(image_path)
 
 
 def merge(images, size):


### PR DESCRIPTION
This pull requests fixes #1. 

Before:
![CRAMER_00000000](https://user-images.githubusercontent.com/9444447/71970073-3b0c2400-3208-11ea-8565-1cab63eaa2b6.png)![CRAMER_00000001](https://user-images.githubusercontent.com/9444447/71970074-3cd5e780-3208-11ea-9f27-cf2653d7c255.png)![CRAMER_00000002](https://user-images.githubusercontent.com/9444447/71970077-3e071480-3208-11ea-81c3-050ec0ad483a.png)

After:
![CRAMER_00000000](https://user-images.githubusercontent.com/9444447/71970094-465f4f80-3208-11ea-90b2-51d0aff6cee2.png)![CRAMER_00000001](https://user-images.githubusercontent.com/9444447/71970100-48291300-3208-11ea-80a0-ad518563cad2.png)![CRAMER_00000002](https://user-images.githubusercontent.com/9444447/71970104-49f2d680-3208-11ea-9824-ff91d3ba86b6.png)


I removed the call to `inverse_transform` since it would scale the images to the wrong value range. 
Also I replaced `scipy.misc.imsave` with an appropriate newer image save method. Since `imsave` got removed in [SciPy 1.2.0](https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.imsave.html)